### PR TITLE
No `wrap` factory methods (bump rdfjs-wrapper to 0.13.0)

### DIFF
--- a/app/lib/class/AccessControl.ts
+++ b/app/lib/class/AccessControl.ts
@@ -1,30 +1,10 @@
 import { Wrapper } from "rdfjs-wrapper"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
 import { Policy } from "@/app/lib/class/Policy"
 import { ACP } from "@/app/lib/class/Vocabulary"
 import { Typed } from "@/app/lib/class/Typed";
 
 export class AccessControl extends Typed {
-    protected constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): AccessControl
-    static wrap(n: Term, dataset: DatasetCore, factory: DataFactory): AccessControl
-    static wrap(nodeOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): AccessControl {
-        if (dataset !== undefined && factory !== undefined) {
-            return new AccessControl(nodeOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = nodeOrWrapper as Wrapper
-            return new AccessControl(term, dataset, factory)
-        }
-    }
-
-    public static wrap2(wrapper: Wrapper): AccessControl {
-        return AccessControl.wrap(wrapper.term, wrapper.dataset, wrapper.factory)
-    }
-
     get apply(): Set<Policy> {
-        return this.objects(ACP.apply, Policy.wrap2, Policy.wrap2)
+        return this.objects(ACP.apply, Wrapper.as(Policy), Wrapper.as(Policy))
     }
 }

--- a/app/lib/class/AccessControlResource.ts
+++ b/app/lib/class/AccessControlResource.ts
@@ -1,27 +1,11 @@
 import { ValueMappings, TermMappings, Wrapper } from "rdfjs-wrapper"
 import { AccessControl } from "@/app/lib/class/AccessControl"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
 import { ACP } from "@/app/lib/class/Vocabulary"
 import { Typed } from "@/app/lib/class/Typed"
 
 export class AccessControlResource extends Typed {
-    protected constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): AccessControlResource
-    static wrap(n: Term, dataset: DatasetCore, factory: DataFactory): AccessControlResource
-    static wrap(nodeOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): AccessControlResource {
-        if (dataset !== undefined && factory !== undefined) {
-            return new AccessControlResource(nodeOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = nodeOrWrapper as Wrapper
-            return new AccessControlResource(term, dataset, factory)
-        }
-    }
-
     get accessControl(): Set<AccessControl> {
-        return this.objects(ACP.accessControl, AccessControl.wrap2, AccessControl.wrap2)
+        return this.objects(ACP.accessControl, Wrapper.as(AccessControl), Wrapper.as(AccessControl))
     }
 
     get resource(): string | undefined {

--- a/app/lib/class/AcrDataset.ts
+++ b/app/lib/class/AcrDataset.ts
@@ -27,7 +27,7 @@ export class AcrDataset {
         const subjects = new Set([...typeSubjects, ...resourceSubjects, ...accessControlSubjects, ...memberAccessControlSubjects])
 
         for (const subject of subjects) {
-            return AccessControlResource.wrap(subject, this.#dataset, this.#factory)
+            return new AccessControlResource(subject, this.#dataset, this.#factory)
         }
     }
 }

--- a/app/lib/class/Agent.ts
+++ b/app/lib/class/Agent.ts
@@ -1,23 +1,7 @@
 import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
 import { FOAF, PIM, SOLID, VCARD } from "@/app/lib/class/Vocabulary"
 
 export class Agent extends Wrapper {
-    protected constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): Agent
-    static wrap(n: Term, dataset: DatasetCore, factory: DataFactory): Agent
-    static wrap(nodeOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): Agent {
-        if (dataset !== undefined && factory !== undefined) {
-            return new Agent(nodeOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = nodeOrWrapper as Wrapper
-            return new Agent(term, dataset, factory)
-        }
-    }
-
     get vcardFn(): string | undefined {
         return this.singularNullable(VCARD.fn, ValueMappings.literalToString)
     }
@@ -43,7 +27,7 @@ export class Agent extends Wrapper {
     }
 
     get hasTelephone(): HasValue | undefined {
-        return this.singularNullable(VCARD.hasTelephone, HasValue.wrap2)
+        return this.singularNullable(VCARD.hasTelephone, Wrapper.as(HasValue))
     }
 
     get foafName(): string | undefined {
@@ -84,7 +68,7 @@ export class Agent extends Wrapper {
     }
 
     get hasEmail(): HasValue | undefined {
-        return this.singularNullable(VCARD.hasEmail, HasValue.wrap2)
+        return this.singularNullable(VCARD.hasEmail, Wrapper.as(HasValue))
     }
 
     get knows(): Set<string> {
@@ -93,25 +77,6 @@ export class Agent extends Wrapper {
 }
 
 class HasValue extends Wrapper {
-    private constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): HasValue
-    static wrap(n: Term, dataset: DatasetCore, factory: DataFactory): HasValue
-    static wrap(nodeOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): HasValue {
-        if (dataset !== undefined && factory !== undefined) {
-            return new HasValue(nodeOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = nodeOrWrapper as Wrapper
-            return new HasValue(term, dataset, factory)
-        }
-    }
-
-    public static wrap2(wrapper: Wrapper): HasValue {
-        return HasValue.wrap(wrapper.term, wrapper.dataset, wrapper.factory)
-    }
-
     get value(): string {
         return this.hasValue ?? this.term.value
     }

--- a/app/lib/class/Container.ts
+++ b/app/lib/class/Container.ts
@@ -1,25 +1,9 @@
 import { Wrapper } from "rdfjs-wrapper"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
 import { Resource } from "@/app/lib/class/Resource"
 import { LDP } from "@/app/lib/class/Vocabulary"
 
 export class Container extends Resource {
-    protected constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): Container
-    static wrap(term: Term, dataset: DatasetCore, factory: DataFactory): Container
-    static wrap(termOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): Container {
-        if (dataset !== undefined && factory !== undefined) {
-            return new Container(termOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = termOrWrapper as Wrapper
-            return new Container(term, dataset, factory)
-        }
-    }
-
     public get contains(): Set<Resource> {
-        return this.objects(LDP.contains, Resource.wrap2, Resource.wrap2)
+        return this.objects(LDP.contains, Wrapper.as(Resource), Wrapper.as(Resource))
     }
 }

--- a/app/lib/class/ContainerDataset.ts
+++ b/app/lib/class/ContainerDataset.ts
@@ -19,7 +19,7 @@ export class ContainerDataset {
     get container(): Container | undefined {
         // Return the first container in the dataset
         for (const q of this.#dataset.match(undefined, LDP.contains)) {
-            return Container.wrap(q.subject, this.#dataset, this.#factory);
+            return new Container(q.subject, this.#dataset, this.#factory);
         }
     }
 }

--- a/app/lib/class/Matcher.ts
+++ b/app/lib/class/Matcher.ts
@@ -1,28 +1,8 @@
-import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
+import { TermMappings, ValueMappings } from "rdfjs-wrapper"
 import { ACP } from "@/app/lib/class/Vocabulary"
-import { Typed } from "@/app/lib/class/Typed";
+import { Typed } from "@/app/lib/class/Typed"
 
 export class Matcher extends Typed {
-    protected constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): Matcher
-    static wrap(n: Term, dataset: DatasetCore, factory: DataFactory): Matcher
-    static wrap(nodeOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): Matcher {
-        if (dataset !== undefined && factory !== undefined) {
-            return new Matcher(nodeOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = nodeOrWrapper as Wrapper
-            return new Matcher(term, dataset, factory)
-        }
-    }
-
-    public static wrap2(wrapper: Wrapper): Matcher {
-        return Matcher.wrap(wrapper.term, wrapper.dataset, wrapper.factory)
-    }
-
     get agent(): Set<string> {
         return this.objects(ACP.agent, ValueMappings.iriToString, TermMappings.stringToIri)
     }

--- a/app/lib/class/Policy.ts
+++ b/app/lib/class/Policy.ts
@@ -1,34 +1,14 @@
-import {TermMappings, ValueMappings, Wrapper} from "rdfjs-wrapper"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
+import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
 import { Matcher } from "@/app/lib/class/Matcher"
 import { ACP } from "@/app/lib/class/Vocabulary"
-import { Typed } from "@/app/lib/class/Typed";
+import { Typed } from "@/app/lib/class/Typed"
 
 export class Policy extends Typed {
-    protected constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): Policy
-    static wrap(n: Term, dataset: DatasetCore, factory: DataFactory): Policy
-    static wrap(nodeOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): Policy {
-        if (dataset !== undefined && factory !== undefined) {
-            return new Policy(nodeOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = nodeOrWrapper as Wrapper
-            return new Policy(term, dataset, factory)
-        }
-    }
-
-    public static wrap2(wrapper: Wrapper): Policy {
-        return Policy.wrap(wrapper.term, wrapper.dataset, wrapper.factory)
-    }
-
     get allow(): Set<string> {
         return this.objects(ACP.allow, ValueMappings.iriToString, TermMappings.stringToIri)
     }
 
     get anyOf(): Set<Matcher> {
-        return this.objects(ACP.anyOf, Matcher.wrap2, Matcher.wrap2)
+        return this.objects(ACP.anyOf, Wrapper.as(Matcher), Wrapper.as(Matcher))
     }
 }

--- a/app/lib/class/Resource.ts
+++ b/app/lib/class/Resource.ts
@@ -1,29 +1,9 @@
 import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
 import { DC, POSIX, RDF, RDFS } from "@/app/lib/class/Vocabulary"
 import { extractNameFromUrl, FileType } from "@/app/lib/helpers"
 
 export class Resource extends Wrapper {
     #ianaMediaTypePattern = /^http:\/\/www\.w3\.org\/ns\/iana\/media-types\/(.+)#Resource$/;
-
-    protected constructor(term: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(term, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): Resource
-    static wrap(term: Term, dataset: DatasetCore, factory: DataFactory): Resource
-    static wrap(termOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): Resource {
-        if (dataset !== undefined && factory !== undefined) {
-            return new Resource(termOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = termOrWrapper as Wrapper
-            return new Resource(term, dataset, factory)
-        }
-    }
-
-    public static wrap2(wrapper: Wrapper): Resource {
-        return Resource.wrap(wrapper.term, wrapper.dataset, wrapper.factory)
-    }
 
     get id(): string {
         return this.term.value

--- a/app/lib/class/Typed.ts
+++ b/app/lib/class/Typed.ts
@@ -1,23 +1,7 @@
 import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
-import type { DataFactory, DatasetCore, Term } from "@rdfjs/types"
 import { RDF } from "@/app/lib/class/Vocabulary"
 
 export class Typed extends Wrapper {
-    protected constructor(node: Term, dataset: DatasetCore, factory: DataFactory) {
-        super(node, dataset, factory)
-    }
-
-    static wrap(wrapper: Wrapper): Typed
-    static wrap(n: Term, dataset: DatasetCore, factory: DataFactory): Typed
-    static wrap(nodeOrWrapper: Term | Wrapper, dataset?: DatasetCore, factory?: DataFactory): Typed {
-        if (dataset !== undefined && factory !== undefined) {
-            return new Typed(nodeOrWrapper as Term, dataset, factory)
-        } else {
-            const {term, dataset, factory} = nodeOrWrapper as Wrapper
-            return new Typed(term, dataset, factory)
-        }
-    }
-
     get type(): Set<string> {
         return this.objects(RDF.type, ValueMappings.iriToString, TermMappings.stringToIri)
     }

--- a/app/lib/class/WebIdDataset.ts
+++ b/app/lib/class/WebIdDataset.ts
@@ -20,7 +20,7 @@ export class WebIdDataset {
         // TODO: do the isPrimaryTopicOf route and the primaryTopic (maybe)
         // Or not because all WebIDs will have an issuer (otherwise also needs to restrict to the document URL as subject or object to realise the benefit)
         for (const q of this.#dataset.match(undefined, SOLID.oidcIssuer)) {
-            return Agent.wrap(q.subject, this.#dataset, this.#factory);
+            return new Agent(q.subject, this.#dataset, this.#factory);
         }
     }
 }

--- a/app/lib/helpers/acpUtils.ts
+++ b/app/lib/helpers/acpUtils.ts
@@ -177,7 +177,7 @@ async function createAcr(
   const { namedNode, blankNode } = DataFactory;
   const ds = new Store
 
-  const acr = AccessControlResource.wrap(namedNode(acrUrl), ds, DataFactory)
+  const acr = new AccessControlResource(namedNode(acrUrl), ds, DataFactory)
 
   // Add ACR type and resource
   acr.type.add(ACP.AccessControlResource.id)
@@ -189,9 +189,9 @@ async function createAcr(
   webIds.forEach((webId) => {
     accessModes.forEach((mode) => {
       // Create blank nodes for nested structure
-      const matcher = Matcher.wrap(blankNode(), ds, DataFactory)
-      const policy = Policy.wrap(blankNode(), ds, DataFactory)
-      const accessControl = AccessControl.wrap(blankNode(), ds, DataFactory)
+      const matcher = new Matcher(blankNode(), ds, DataFactory)
+      const policy = new Policy(blankNode(), ds, DataFactory)
+      const accessControl = new AccessControl(blankNode(), ds, DataFactory)
 
       // Matcher: type and agent
       matcher.type.add(ACP.Matcher.id)
@@ -273,15 +273,15 @@ async function updateAcr(
   const { namedNode, blankNode } = DataFactory;
 
   const ds = new Store
-  const acr = AccessControlResource.wrap(namedNode(acrUrl), ds, DataFactory)
+  const acr = new AccessControlResource(namedNode(acrUrl), ds, DataFactory)
 
   // Create new access controls for new WebIDs
   newWebIds.forEach((webId) => {
     const accessModes = getAccessModes(accessLevel);
     accessModes.forEach((mode) => {
-      const matcher = Matcher.wrap(blankNode(), ds, DataFactory)
-      const policy = Policy.wrap(blankNode(), ds, DataFactory)
-      const accessControl = AccessControl.wrap(blankNode(), ds, DataFactory)
+      const matcher = new Matcher(blankNode(), ds, DataFactory)
+      const policy = new Policy(blankNode(), ds, DataFactory)
+      const accessControl = new AccessControl(blankNode(), ds, DataFactory)
 
       matcher.type.add(ACP.Matcher.id)
       matcher.agent.add(webId)
@@ -418,7 +418,7 @@ export async function getResourceAccessList(resourceUrl: string): Promise<Array<
     const dataset = new Store();
     dataset.addQuads(new Parser().parse(turtle));
 
-    const acr = AccessControlResource.wrap(DataFactory.namedNode(acrUrl), dataset, DataFactory)
+    const acr = new AccessControlResource(DataFactory.namedNode(acrUrl), dataset, DataFactory)
 
     const rawModesByWebId =
       [...acr.accessControl].flatMap(ac =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "jszip": "^3.10.1",
         "n3": "^2.0.1",
         "next": "16.0.7",
-        "rdfjs-wrapper": "^0.12.0",
+        "rdfjs-wrapper": "^0.13.0",
         "react": "19.2.1",
         "react-dom": "19.2.1",
         "react-hot-toast": "^2.6.0"
@@ -16780,9 +16780,9 @@
       }
     },
     "node_modules/rdfjs-wrapper": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/rdfjs-wrapper/-/rdfjs-wrapper-0.12.0.tgz",
-      "integrity": "sha512-SO2Lf7bWLZwxq5vJCLI3AdbN/AV0vVeo4SVPvZNDIFukgpygPe/A14wnPcjgcBaz6Tl6Kswq9oO3lIaTuds3uw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/rdfjs-wrapper/-/rdfjs-wrapper-0.13.0.tgz",
+      "integrity": "sha512-Nx8/y1H7qiPs9gBrv3l1B9zOIgyHleyoibRtKYYlmv54ztcPwkAsxAcvk/kJIKdrpYoFw0jzmUPo1AdFAkf6dA==",
       "license": "MIT",
       "engines": {
         "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jszip": "^3.10.1",
     "n3": "^2.0.1",
     "next": "16.0.7",
-    "rdfjs-wrapper": "^0.12.0",
+    "rdfjs-wrapper": "^0.13.0",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-hot-toast": "^2.6.0"


### PR DESCRIPTION
Serious reduction in boilerplate due to simplification in the wrapping library.
Mapping classes now consist of nothing but their properties.

Changes to the rest of the code (other than mappers) is negligible.

For the substantial addition to the underlying library see [this](https://github.com/theodi/rdfjs-wrapper/commit/19624f00816bba77110755b14e28a807760c0d65#diff-1d6ab11468a8dd759be6d0836932fc41b2d082ac7fc8e45c102b1265d6446cdeR17-R20).

@matthieubosquet will be most familiar with the background for these changes, I recommend he reviews.
Anyone else, I'm more than happy to explain more.
