### PR TITLE
Dataset wrapping: Reduce mapping boilerplate

### DIFF
--- a/app/lib/class/AccessControl.ts
+++ b/app/lib/class/AccessControl.ts
@@ -1,10 +1,10 @@
-import { Wrapper } from "rdfjs-wrapper"
+import { TermWrapper } from "rdfjs-wrapper"
 import { Policy } from "@/app/lib/class/Policy"
 import { ACP } from "@/app/lib/class/Vocabulary"
 import { Typed } from "@/app/lib/class/Typed";
 
 export class AccessControl extends Typed {
     get apply(): Set<Policy> {
-        return this.objects(ACP.apply, Wrapper.as(Policy), Wrapper.as(Policy))
+        return this.objects(ACP.apply, TermWrapper.as(Policy), TermWrapper.as(Policy))
     }
 }

--- a/app/lib/class/AccessControlResource.ts
+++ b/app/lib/class/AccessControlResource.ts
@@ -1,11 +1,11 @@
-import { ValueMappings, TermMappings, Wrapper } from "rdfjs-wrapper"
+import { ValueMappings, TermMappings, TermWrapper } from "rdfjs-wrapper"
 import { AccessControl } from "@/app/lib/class/AccessControl"
 import { ACP } from "@/app/lib/class/Vocabulary"
 import { Typed } from "@/app/lib/class/Typed"
 
 export class AccessControlResource extends Typed {
     get accessControl(): Set<AccessControl> {
-        return this.objects(ACP.accessControl, Wrapper.as(AccessControl), Wrapper.as(AccessControl))
+        return this.objects(ACP.accessControl, TermWrapper.as(AccessControl), TermWrapper.as(AccessControl))
     }
 
     get resource(): string | undefined {

--- a/app/lib/class/AcrDataset.ts
+++ b/app/lib/class/AcrDataset.ts
@@ -1,33 +1,18 @@
-import type { DataFactory, DatasetCore } from "@rdfjs/types"
+import { DatasetWrapper } from "rdfjs-wrapper"
 import { AccessControlResource } from "@/app/lib/class/AccessControlResource";
-import { ACP, RDF } from "@/app/lib/class/Vocabulary"
+import { ACP } from "@/app/lib/class/Vocabulary"
 
-export class AcrDataset {
-    readonly #dataset: DatasetCore
-    readonly #factory: DataFactory
-
-    protected constructor(dataset: DatasetCore, factory: DataFactory) {
-        this.#dataset = dataset
-        this.#factory = factory
-    }
-
-    static wrap(dataset: DatasetCore, factory: DataFactory): AcrDataset {
-        return new AcrDataset(dataset, factory)
-    }
-
-    get dataset(): DatasetCore {
-        return this.#dataset
-    }
-
+export class AcrDataset extends DatasetWrapper {
     get acr(): AccessControlResource | undefined {
-        const typeSubjects = [...this.dataset.match(undefined, RDF.type, ACP.AccessControlResource)].map(q => q.subject)
-        const resourceSubjects = [...this.dataset.match(undefined, ACP.resource)].map(q => q.subject)
-        const accessControlSubjects = [...this.dataset.match(undefined, ACP.accessControl)].map(q => q.subject)
-        const memberAccessControlSubjects = [...this.dataset.match(undefined, ACP.memberAccessControl)].map(q => q.subject)
-        const subjects = new Set([...typeSubjects, ...resourceSubjects, ...accessControlSubjects, ...memberAccessControlSubjects])
+        const subjects = new Set([
+            ...this.instancesOf(AccessControlResource, ACP.AccessControlResource),
+            ...this.subjectsOf(AccessControlResource, ACP.resource),
+            ...this.subjectsOf(AccessControlResource, ACP.accessControl),
+            ...this.subjectsOf(AccessControlResource, ACP.memberAccessControl)
+        ])
 
         for (const subject of subjects) {
-            return new AccessControlResource(subject, this.#dataset, this.#factory)
+            return subject
         }
     }
 }

--- a/app/lib/class/Agent.ts
+++ b/app/lib/class/Agent.ts
@@ -1,7 +1,7 @@
-import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
+import { TermMappings, ValueMappings, TermWrapper } from "rdfjs-wrapper"
 import { FOAF, PIM, SOLID, VCARD } from "@/app/lib/class/Vocabulary"
 
-export class Agent extends Wrapper {
+export class Agent extends TermWrapper {
     get vcardFn(): string | undefined {
         return this.singularNullable(VCARD.fn, ValueMappings.literalToString)
     }
@@ -27,7 +27,7 @@ export class Agent extends Wrapper {
     }
 
     get hasTelephone(): HasValue | undefined {
-        return this.singularNullable(VCARD.hasTelephone, Wrapper.as(HasValue))
+        return this.singularNullable(VCARD.hasTelephone, TermWrapper.as(HasValue))
     }
 
     get foafName(): string | undefined {
@@ -68,7 +68,7 @@ export class Agent extends Wrapper {
     }
 
     get hasEmail(): HasValue | undefined {
-        return this.singularNullable(VCARD.hasEmail, Wrapper.as(HasValue))
+        return this.singularNullable(VCARD.hasEmail, TermWrapper.as(HasValue))
     }
 
     get knows(): Set<string> {
@@ -76,7 +76,7 @@ export class Agent extends Wrapper {
     }
 }
 
-class HasValue extends Wrapper {
+class HasValue extends TermWrapper {
     get value(): string {
         return this.hasValue ?? this.term.value
     }

--- a/app/lib/class/Container.ts
+++ b/app/lib/class/Container.ts
@@ -1,9 +1,9 @@
-import { Wrapper } from "rdfjs-wrapper"
+import { TermWrapper } from "rdfjs-wrapper"
 import { Resource } from "@/app/lib/class/Resource"
 import { LDP } from "@/app/lib/class/Vocabulary"
 
 export class Container extends Resource {
     public get contains(): Set<Resource> {
-        return this.objects(LDP.contains, Wrapper.as(Resource), Wrapper.as(Resource))
+        return this.objects(LDP.contains, TermWrapper.as(Resource), TermWrapper.as(Resource))
     }
 }

--- a/app/lib/class/ContainerDataset.ts
+++ b/app/lib/class/ContainerDataset.ts
@@ -1,25 +1,13 @@
-import type { DataFactory, DatasetCore } from "@rdfjs/types"
+import { DatasetWrapper } from "rdfjs-wrapper"
 import { Container } from "@/app/lib/class/Container"
 import { LDP } from "@/app/lib/class/Vocabulary"
 
-export class ContainerDataset {
-    #dataset: DatasetCore
-    #factory: DataFactory
-
-    protected constructor(dataset: DatasetCore, factory: DataFactory) {
-        this.#dataset = dataset
-        this.#factory = factory
-    }
-
-    static wrap(dataset: DatasetCore, factory: DataFactory): ContainerDataset {
-        return new ContainerDataset(dataset, factory)
-    }
-
+export class ContainerDataset extends DatasetWrapper {
     // TODO: Consider that this might be undefined if there are no contained resources. We might need different matching.
     get container(): Container | undefined {
         // Return the first container in the dataset
-        for (const q of this.#dataset.match(undefined, LDP.contains)) {
-            return new Container(q.subject, this.#dataset, this.#factory);
+        for (const s of this.subjectsOf(Container, LDP.contains)) {
+            return s;
         }
     }
 }

--- a/app/lib/class/Policy.ts
+++ b/app/lib/class/Policy.ts
@@ -1,4 +1,4 @@
-import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
+import { TermMappings, ValueMappings, TermWrapper } from "rdfjs-wrapper"
 import { Matcher } from "@/app/lib/class/Matcher"
 import { ACP } from "@/app/lib/class/Vocabulary"
 import { Typed } from "@/app/lib/class/Typed"
@@ -9,6 +9,6 @@ export class Policy extends Typed {
     }
 
     get anyOf(): Set<Matcher> {
-        return this.objects(ACP.anyOf, Wrapper.as(Matcher), Wrapper.as(Matcher))
+        return this.objects(ACP.anyOf, TermWrapper.as(Matcher), TermWrapper.as(Matcher))
     }
 }

--- a/app/lib/class/Resource.ts
+++ b/app/lib/class/Resource.ts
@@ -1,8 +1,8 @@
-import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
+import { TermMappings, ValueMappings, TermWrapper } from "rdfjs-wrapper"
 import { DC, POSIX, RDF, RDFS } from "@/app/lib/class/Vocabulary"
 import { extractNameFromUrl, FileType } from "@/app/lib/helpers"
 
-export class Resource extends Wrapper {
+export class Resource extends TermWrapper {
     #ianaMediaTypePattern = /^http:\/\/www\.w3\.org\/ns\/iana\/media-types\/(.+)#Resource$/;
 
     get id(): string {

--- a/app/lib/class/Typed.ts
+++ b/app/lib/class/Typed.ts
@@ -1,7 +1,7 @@
-import { TermMappings, ValueMappings, Wrapper } from "rdfjs-wrapper"
+import { TermMappings, ValueMappings, TermWrapper } from "rdfjs-wrapper"
 import { RDF } from "@/app/lib/class/Vocabulary"
 
-export class Typed extends Wrapper {
+export class Typed extends TermWrapper {
     get type(): Set<string> {
         return this.objects(RDF.type, ValueMappings.iriToString, TermMappings.stringToIri)
     }

--- a/app/lib/class/WebIdDataset.ts
+++ b/app/lib/class/WebIdDataset.ts
@@ -1,26 +1,14 @@
-import type { DataFactory, DatasetCore } from "@rdfjs/types"
+import { DatasetWrapper } from "rdfjs-wrapper"
 import { Agent } from "@/app/lib/class/Agent"
 import { SOLID } from "@/app/lib/class/Vocabulary"
 
-export class WebIdDataset {
-    #dataset: DatasetCore
-    #factory: DataFactory
-
-    protected constructor(dataset: DatasetCore, factory: DataFactory) {
-        this.#dataset = dataset
-        this.#factory = factory
-    }
-
-    static wrap(dataset: DatasetCore, factory: DataFactory): WebIdDataset {
-        return new WebIdDataset(dataset, factory)
-    }
-
+export class WebIdDataset extends DatasetWrapper{
     get mainSubject(): Agent | undefined {
         // TODO: Fix with FOAF: Primary topic either via Inrupt or spec because this does not work with Inrupt WebID
         // TODO: do the isPrimaryTopicOf route and the primaryTopic (maybe)
         // Or not because all WebIDs will have an issuer (otherwise also needs to restrict to the document URL as subject or object to realise the benefit)
-        for (const q of this.#dataset.match(undefined, SOLID.oidcIssuer)) {
-            return new Agent(q.subject, this.#dataset, this.#factory);
+        for (const s of this.subjectsOf(Agent, SOLID.oidcIssuer)) {
+            return s;
         }
     }
 }

--- a/app/lib/helpers/acpUtils.ts
+++ b/app/lib/helpers/acpUtils.ts
@@ -140,7 +140,7 @@ async function fetchAcr(acrUrl: string, fetchFn: typeof fetch): Promise<AcrDatas
     dataset.addQuads(new Parser().parse(content));
 
     // Get typed AccessControlResource from the dataset
-    const acrDataset = AcrDataset.wrap(dataset, DataFactory)
+    const acrDataset = new AcrDataset(dataset, DataFactory)
 
     if (acrDataset.acr === undefined) {
       throw new Error // TODO: Handle properly
@@ -211,7 +211,7 @@ async function createAcr(
     });
   });
 
-  return AcrDataset.wrap(ds, DataFactory)
+  return new AcrDataset(ds, DataFactory)
 }
 
 function write(ds: DatasetCore): Promise<string> {
@@ -328,7 +328,7 @@ export async function shareResourceWithAcp(
     headers: {
       "Content-Type": "text/turtle",
     },
-    body: await write(acrDataset.dataset),
+    body: await write(acrDataset),
   });
 
   if (!response.ok) {

--- a/app/lib/helpers/profileUtils.ts
+++ b/app/lib/helpers/profileUtils.ts
@@ -73,7 +73,7 @@ export async function fetchAndParseProfile(webId: string): Promise<Agent> {
     }
   }
 
-  const webIdDataset = WebIdDataset.wrap(store, DataFactory);
+  const webIdDataset = new WebIdDataset(store, DataFactory);
 
   const mainSubject: Agent | undefined = webIdDataset.mainSubject;
   if (mainSubject === undefined) {

--- a/app/lib/hooks/useBrowseStorage.ts
+++ b/app/lib/hooks/useBrowseStorage.ts
@@ -52,7 +52,7 @@ export function useBrowseStorage(containerUrl: string | null, refreshKey?: numbe
         // Use @inrupt/solid-client to fetch the container dataset
         // and map it to plain object-oriented classes using rdfjs-wrapper
         const container =
-            ContainerDataset.wrap(
+            new ContainerDataset(
                 toRdfJsDataset(await getSolidDataset(url, {fetch: cacheBustingFetch})),
                 DataFactory)
                 .container

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "jszip": "^3.10.1",
         "n3": "^2.0.1",
         "next": "16.0.7",
-        "rdfjs-wrapper": "^0.13.0",
+        "rdfjs-wrapper": "^0.14.0",
         "react": "19.2.1",
         "react-dom": "19.2.1",
         "react-hot-toast": "^2.6.0"
@@ -16780,9 +16780,9 @@
       }
     },
     "node_modules/rdfjs-wrapper": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/rdfjs-wrapper/-/rdfjs-wrapper-0.13.0.tgz",
-      "integrity": "sha512-Nx8/y1H7qiPs9gBrv3l1B9zOIgyHleyoibRtKYYlmv54ztcPwkAsxAcvk/kJIKdrpYoFw0jzmUPo1AdFAkf6dA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/rdfjs-wrapper/-/rdfjs-wrapper-0.14.0.tgz",
+      "integrity": "sha512-6Jt/tUa6xS37i7+ILDrmJOlzMUWhq4Z6AsA9hbgziXVnRwfWDsx2x8XaZxZXVI7Z7kI2/d2dVz1dtpWNeF3h7g==",
       "license": "MIT",
       "engines": {
         "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jszip": "^3.10.1",
     "n3": "^2.0.1",
     "next": "16.0.7",
-    "rdfjs-wrapper": "^0.13.0",
+    "rdfjs-wrapper": "^0.14.0",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-hot-toast": "^2.6.0"


### PR DESCRIPTION
More reduction in boilerplate due to simplification in the wrapping library.
There is now a dataset wrapper base class that helps author dataset mapping classes.

Underlying change is https://github.com/theodi/rdfjs-wrapper/commit/3b3efae807a4d365e0e1b714a1817f0b0b3c0562#diff-8f203654f24347d054552be4dfd689ccf56b81370498451442c19320c4b65af4.